### PR TITLE
Fix `resolves` in example workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An example workflow to deploy a project with serverless:
 ```
 workflow "Deploy with Serverless" {
   on = "push"
-  resolves = "release"
+  resolves = "serverless deploy"
 }
 
 action "serverless deploy" {


### PR DESCRIPTION
Current example workflow throws an error, this resolves it - `resolves` has to match an `action`.