### PR TITLE
Update Docker image to use Node 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:11-slim
 
 
 LABEL version="1.0.0"


### PR DESCRIPTION
Proposing updating this Docker image to be based on the Node [`11-slim` Dockerfile](https://github.com/nodejs/docker-node/blob/master/11/stretch-slim/Dockerfile) - the latest version.