### PR TITLE
Add support for Python & Ruby runtimes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,10 @@ LABEL "com.github.actions.description"="Wraps the Serverless Frameork to enable 
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="red"
 
+RUN apt-get install software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update && \
-    apt-get install -qq -y python2.7 python3.6 ruby python-pip python3-pip python-setuptools python3-setuptools software-properties-common
+    apt-get install -qq -y python2.7 python3.6 ruby python-pip python3-pip python-setuptools python3-setuptools
 
 RUN npm i -g serverless
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="red"
 
 RUN apt-get update && \
-    apt-get install -qq -y python2.7 python3 ruby python-pip python3-pip python-setuptools python3-setuptools
+    apt-get install -qq -y python2.7 python3.6 ruby python-pip python3-pip python-setuptools python3-setuptools
 
 RUN npm i -g serverless
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ LABEL "com.github.actions.description"="Wraps the Serverless Frameork to enable 
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="red"
 
+RUN apt-get update
 RUN apt-get install software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ LABEL "com.github.actions.description"="Wraps the Serverless Frameork to enable 
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="red"
 
+RUN apt-get update && \
+    apt-get install -qq -y python2.7 python3 ruby
+
 RUN npm i -g serverless
 
 ENTRYPOINT ["serverless"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="red"
 
 RUN apt-get update && \
-    apt-get install -qq -y python2.7 python3 ruby
+    apt-get install -qq -y python2.7 python3 ruby python-pip python3-pip python-setuptools python3-setuptools
 
 RUN npm i -g serverless
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ LABEL "com.github.actions.description"="Wraps the Serverless Frameork to enable 
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="red"
 
+RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update && \
-    apt-get install -qq -y python2.7 python3.6 ruby python-pip python3-pip python-setuptools python3-setuptools
+    apt-get install -qq -y python2.7 python3.6 ruby python-pip python3-pip python-setuptools python3-setuptools software-properties-common
 
 RUN npm i -g serverless
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="red"
 
 RUN apt-get update
-RUN apt-get install software-properties-common
+RUN apt-get install -qq -y software-properties-common
 RUN add-apt-repository ppa:deadsnakes/ppa
 RUN apt-get update && \
     apt-get install -qq -y python2.7 python3.6 ruby python-pip python3-pip python-setuptools python3-setuptools


### PR DESCRIPTION
Proposing adding support for Python (2.7 + 3.6.7) and Ruby (2.3.3p222) runtimes. These are the default versions pulled by `apt-get`, not the latest and certainly not all, but it's a good start!