### PR TITLE
Updated npm install step in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: npm install
-      uses: actions/npm@master
-      with:
-        args: install
+      run: npm install
     - name: serverless deploy
       uses: serverless/github-action@master
       with:


### PR DESCRIPTION
As per the [docs](https://github.com/actions/npm). The `actions/npm` action is deprecated in favor of using the run script step.