### PR TITLE
feat: use alpine version to reduce vulnerabilities in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:python3.9-nodejs14-slim
+FROM nikolaik/python-nodejs:python3.9-nodejs14-alpine
 
 LABEL version="1.0.0"
 LABEL repository="https://github.com/serverless/github-action"


### PR DESCRIPTION
This PR uses alpine version of the image to reduce OS vulnerabilities in image. Scans were done using trivy image scanning - https://github.com/aquasecurity/trivy

cc @DavideViolante 

**From this:** 

nikolaik/python-nodejs:python3.9-nodejs14-slim (debian 10.8)
Total: 29 (HIGH: 21, CRITICAL: 8)

**to:** 

nikolaik/python-nodejs:python3.9-nodejs14-alpine (alpine 3.13.2)
Total: 0 (HIGH: 0, CRITICAL: 0)

