### PR TITLE
Switch to LTS version (v18) of Node.js

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nikolaik/python-nodejs:python3.10-nodejs16-slim
+FROM nikolaik/python-nodejs:python3.10-nodejs18-slim
 
 LABEL version="1.0.0"
 LABEL repository="https://github.com/serverless/github-action"


### PR DESCRIPTION
Switching to Node.js v18 which is the current LTS version.

Node.js v16 End of Life is in 11 Sep 2023 (4 months from now): Active Support period ended 6 months ago (18 Oct 2022) and Security Support period will end in 4 months (11 Sep 2023).

Current LTS version is v18.

![CleanShot 2023-05-03 at 18 08 06@2x](https://user-images.githubusercontent.com/23618431/236084393-384683bc-9e93-45b2-a7d9-14dcbe36e755.png)
![CleanShot 2023-05-03 at 18 08 14@2x](https://user-images.githubusercontent.com/23618431/236084398-eb6e22f1-4397-4c75-a3f6-2fc3757c4418.png)

On a few projects I was having issues with the action which is what prompted this pr. When I removed the action and used the npm package to deploy, it worked. I then tested deploying the action to a self-hosted runner with the Node.js version up'd to 18, worked with no problems.

ref: https://nodejs.dev/en/about/releases/