### PR TITLE
Add action file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,27 @@
+name: 'Serverless GitHub Action'
+description: 'Wraps the Serverless Framework to enable common Serverless commands'
+author: 'Serverless, Inc. <hello@serverless.com> (https://serverless.com)'
+branding:
+  icon: 'zap'
+  color: 'red'
+
+inputs:
+  args:
+    description: 'Serverless cli arguments'
+    required: false
+  entrypoint:
+    description: 'Serverless entrypoint. For example: `/bin/sh`'
+    required: false
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.args }}
+  entrypoint: ${{ inputs.entrypoint }}
+
+outputs:
+  version:
+    description: 'Serverless Framework version'
+  result:
+    description: 'Serverless Framework result'


### PR DESCRIPTION
Followed this guide: https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action

The motivation behind this PR is to provide support in editors and prevent eroror / squiggly red line when using this action:

![CleanShot 2023-05-04 at 05 20 14@2x](https://user-images.githubusercontent.com/23618431/236204348-f6076b87-b9c7-4b5e-9876-a12e43a164fb.png)
 ^ This error is due to missing `action.yml`. It still lets you use the action but doesn't provide you with any hints/autocomplete.

The `action.yml` file allows the [official GitHub VSCode extension](https://github.com/github/vscode-github-actions) to provide descriptions and autocomplete when using the action. For example, here's the autocomplete support for `actions/checkout@v3`:

![CleanShot 2023-05-04 at 05 33 08@2x](https://user-images.githubusercontent.com/23618431/236205449-7d14b028-b1fe-4be6-9f26-d4eddcbe6b3f.png)

Is there a way an admin of this repo could create a `next` branch to merge this into instead of merging to `master` first? This is so I can further verify the types and autocomplete support (in addition to the testing I've done).
Once merged to `next`, I use the action like this:

```yml
# ...
uses: serverless/github-action@next
# ...
```

Then once all is good, I report back and request merge to `master`