### PR TITLE
Add customization options for Serverless action

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,6 @@ LABEL "com.github.actions.description"="Wraps the Serverless Framework to enable
 LABEL "com.github.actions.icon"="zap"
 LABEL "com.github.actions.color"="red"
 
-RUN npm i -g serverless@3.x
-ENTRYPOINT ["serverless"]
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ jobs:
         # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
 
+## Specify a particular version
+```yaml
+    - name: Deploy with a particular version
+      uses: serverless/github-action@v3.2
+      with:
+        serverless-version: 3
+```
+
 ## Usage with serverless plugins
 Change your action in this way, according to [this issue](https://github.com/serverless/github-action/issues/28), thanks to @matthewpoer:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ jobs:
       uses: serverless/github-action@v3.2
       with:
         serverless-version: 3
+        args: deploy
+```
+
+## Change your working directory
+```yaml
+    - name: Deploy from a particular working directory
+      uses: serverless/github-action@v3.2
+      with:
+        working-directory: ./foo
+        args: deploy
 ```
 
 ## Usage with serverless plugins

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This Action wraps the [Serverless Framework](https://serverless.com) to enable c
 
 An example workflow to deploy a project with the Serverless Framework:
 
-
 ```yaml
 name: Deploy master branch
 
@@ -30,7 +29,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - name: serverless deploy
-      uses: serverless/github-action@v3.2
+      uses: ryanlawson/serverless-github-action@v1.0
       with:
         args: deploy
       env:
@@ -53,6 +52,7 @@ jobs:
 ## Examples
 
 ### Minimal example
+Basic deployment with no customization
 ```yaml
     - name: Deploy
       uses: ryanlawson/serverless-github-action@v1.0
@@ -61,6 +61,7 @@ jobs:
 ```
 
 ### Use local credentials
+Ensures `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are present and uses them to authenticate
 ```yaml
     - name: Deploy with local credentials
       uses: ryanlawson/serverless-github-action@v1.0
@@ -73,6 +74,7 @@ jobs:
 ```
 
 ### Install packages and deploy
+Installs any additional packages (usually [Serverless plugins](https://www.serverless.com/plugins)) prior to deploying
 ```yaml
     - name: Install packages and deploy
       uses: ryanlawson/serverless-github-action@v1.0
@@ -82,6 +84,7 @@ jobs:
 ```
 
 ### Use a particular Serverless Framework CLI version
+Installs a specific version of the Serverless Framework
 ```yaml
     - name: Deploy using a particular version of serverless
       uses: ryanlawson/serverless-github-action@v1.0
@@ -91,6 +94,7 @@ jobs:
 ```
 
 ### Change your working directory
+Sets a specific working directory (usually the root of the repository) for your Serverless configuration
 ```yaml
     - name: Deploy from a particular working directory
       uses: ryanlawson/serverless-github-action@v1.0

--- a/README.md
+++ b/README.md
@@ -46,16 +46,67 @@ jobs:
         # AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
 
-## Specify a particular version
+## Configuration
+
+| `with:` | Description | Required | Default |
+| --- | --- | --- | --- |
+| `args` | Arguments passed to `serverless` | `true` |
+| `aws-credentials` | Whether to use credentials stored in the local environment (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) | `false` |  |
+| `entrypoint` | Serverless entrypoint. For example: `/bin/sh` | `false` | `/entrypoint.sh` |
+| `install-packages` | Comma-separated list of packages to install prior to running `serverless {args}` | `false` |  |
+| `serverless-version` | Version of the Serverless Framework to use | `false` | `latest` |
+| `working-directory` | Folder where your configuration is located | `false` | `.` |
+
+## Examples
+
+### Minimal example
 ```yaml
-    - name: Deploy with a particular version
+    - name: Deploy
       uses: serverless/github-action@v3.2
       with:
-        serverless-version: 3
         args: deploy
 ```
 
-## Change your working directory
+### Use local credentials
+```yaml
+    - name: Deploy with local credentials
+      uses: serverless/github-action@v3.2
+      with:
+        aws-credentials: true # or yes
+        args: deploy
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+
+### Use a different entrypoint
+```yaml
+    - name: Deploy with a different entrypoint
+      uses: serverless/github-action@v3.2
+      with:
+        entrypoint: /bin/sh
+        args: -c "serverless deploy"
+```
+
+### Install packages and deploy
+```yaml
+    - name: Install packages and deploy
+      uses: serverless/github-action@v3.2
+      with:
+        install-packages: serverless-offline,serverless-prune-plugin
+        args: deploy
+```
+
+### Use a particular Serverless Framework CLI version
+```yaml
+    - name: Deploy using a particular version of serverless
+      uses: serverless/github-action@v3.2
+      with:
+        serverless-version: 2
+        args: deploy
+```
+
+### Change your working directory
 ```yaml
     - name: Deploy from a particular working directory
       uses: serverless/github-action@v3.2

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ jobs:
 | --- | --- | --- | --- |
 | `args` | Arguments passed to `serverless` | `true` |
 | `aws-credentials` | Whether to use credentials stored in the local environment (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) | `false` |  |
-| `entrypoint` | Serverless entrypoint. For example: `/bin/sh` | `false` | `/entrypoint.sh` |
-| `install-packages` | Comma-separated list of packages to install prior to running `serverless {args}` | `false` |  |
+| `install-packages` | Space-separated list of packages to install prior to running `serverless {args}` | `false` |  |
 | `serverless-version` | Version of the Serverless Framework to use | `false` | `latest` |
 | `working-directory` | Folder where your configuration is located | `false` | `.` |
 
@@ -62,7 +61,7 @@ jobs:
 ### Minimal example
 ```yaml
     - name: Deploy
-      uses: serverless/github-action@v3.2
+      uses: serverless/github-action@v4.0
       with:
         args: deploy
 ```
@@ -70,7 +69,7 @@ jobs:
 ### Use local credentials
 ```yaml
     - name: Deploy with local credentials
-      uses: serverless/github-action@v3.2
+      uses: serverless/github-action@v4.0
       with:
         aws-credentials: true # or yes
         args: deploy
@@ -79,28 +78,19 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 ```
 
-### Use a different entrypoint
-```yaml
-    - name: Deploy with a different entrypoint
-      uses: serverless/github-action@v3.2
-      with:
-        entrypoint: /bin/sh
-        args: -c "serverless deploy"
-```
-
 ### Install packages and deploy
 ```yaml
     - name: Install packages and deploy
-      uses: serverless/github-action@v3.2
+      uses: serverless/github-action@v4.0
       with:
-        install-packages: serverless-offline,serverless-prune-plugin
+        install-packages: serverless-offline serverless-prune-plugin
         args: deploy
 ```
 
 ### Use a particular Serverless Framework CLI version
 ```yaml
     - name: Deploy using a particular version of serverless
-      uses: serverless/github-action@v3.2
+      uses: serverless/github-action@v4.0
       with:
         serverless-version: 2
         args: deploy
@@ -109,42 +99,17 @@ jobs:
 ### Change your working directory
 ```yaml
     - name: Deploy from a particular working directory
-      uses: serverless/github-action@v3.2
+      uses: serverless/github-action@v4.0
       with:
         working-directory: ./foo
         args: deploy
 ```
 
-## Usage with serverless plugins
-Change your action in this way, according to [this issue](https://github.com/serverless/github-action/issues/28), thanks to @matthewpoer:
+## Use a previous version
+Change the action with `@{version}`, for example:
 ```yaml
-    - name: Install Plugin and Deploy
-      uses: serverless/github-action@v3.2
-      with:
-        args: -c "serverless plugin install --name <plugin-name> && serverless deploy"
-        entrypoint: /bin/sh
+uses: serverless/github-action@v3.2
 ```
-
-## Fix "This command can only be run in a Serverless service directory" error
-Change your action in this way, according to [this issue](https://github.com/serverless/github-action/issues/53#issuecomment-1059839383), thanks to @nikhuber:
-```yaml
-    - name: Enter dir and deploy
-      uses: serverless/github-action@v3.2
-      with:
-        args: -c "cd ./<your-dir> && serverless deploy"
-        entrypoint: /bin/sh
-```
-
-
-## Use serverless v1 or v2
-Change the action with one of the following:
-```yaml
-uses: serverless/github-action@v1
-```
-```yaml
-uses: serverless/github-action@v2
-```
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,9 @@
 
 This Action wraps the [Serverless Framework](https://serverless.com) to enable common Serverless commands.
 
-## This project is looking for maintainers!
-
-If you would like to be a maintainer of this project, please reach out to one of the active [Serverless organization](https://github.com/serverless) members to express your interest.
-
-Welcome, and thanks in advance for your help!
-
 ## Usage
 
-An example workflow to deploy a project with serverless v3:
+An example workflow to deploy a project with the Serverless Framework:
 
 
 ```yaml
@@ -61,7 +55,7 @@ jobs:
 ### Minimal example
 ```yaml
     - name: Deploy
-      uses: serverless/github-action@v4.0
+      uses: ryanlawson/serverless-github-action@v1.0
       with:
         args: deploy
 ```
@@ -69,7 +63,7 @@ jobs:
 ### Use local credentials
 ```yaml
     - name: Deploy with local credentials
-      uses: serverless/github-action@v4.0
+      uses: ryanlawson/serverless-github-action@v1.0
       with:
         aws-credentials: true # or yes
         args: deploy
@@ -81,7 +75,7 @@ jobs:
 ### Install packages and deploy
 ```yaml
     - name: Install packages and deploy
-      uses: serverless/github-action@v4.0
+      uses: ryanlawson/serverless-github-action@v1.0
       with:
         install-packages: serverless-offline serverless-prune-plugin
         args: deploy
@@ -90,7 +84,7 @@ jobs:
 ### Use a particular Serverless Framework CLI version
 ```yaml
     - name: Deploy using a particular version of serverless
-      uses: serverless/github-action@v4.0
+      uses: ryanlawson/serverless-github-action@v1.0
       with:
         serverless-version: 2
         args: deploy
@@ -99,16 +93,10 @@ jobs:
 ### Change your working directory
 ```yaml
     - name: Deploy from a particular working directory
-      uses: serverless/github-action@v4.0
+      uses: ryanlawson/serverless-github-action@v1.0
       with:
         working-directory: ./foo
         args: deploy
-```
-
-## Use a previous version
-Change the action with `@{version}`, for example:
-```yaml
-uses: serverless/github-action@v3.2
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,14 @@ inputs:
     description: 'Version of the Serverless Framework to use (default: latest)'
     required: false
     default: latest
+  working-directory:
+    description: 'Folder where your configuration is located'
+    required: false
+    default: .
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
+    - ${{ inputs.working-directory }}
     - ${{ inputs.serverless-version }}
     - ${{ inputs.args }}

--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,15 @@ branding:
 inputs:
   args:
     description: 'Arguments passed to `serverless`'
+    required: true
+  aws-credentials:
+    description: 'Whether to use credentials stored in the local environment (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)'
     required: false
-    default: help
-  entrypoint:
-    description: 'Serverless entrypoint. For example: `/bin/sh`'
+    default: 'false'
+  install-packages:
+    description: 'Comma-separated list of packages to install prior to running `serverless {args}`'
     required: false
+    default: none
   serverless-version:
     description: 'Version of the Serverless Framework to use (default: latest)'
     required: false
@@ -26,8 +30,9 @@ runs:
   args:
     - ${{ inputs.working-directory }}
     - ${{ inputs.serverless-version }}
+    - ${{ inputs.install-packages }}
+    - ${{ inputs.aws-credentials }}
     - ${{ inputs.args }}
-  entrypoint: ${{ inputs.entrypoint }}
 
 outputs:
   version:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,17 @@
+name: 'Serverless Github Action'
+description: 'Github Action for the Serverless Framework'
+inputs:
+  args:
+    description: 'Arguments passed to `serverless`'
+    required: false
+    default: help
+  serverless-version:
+    description: 'Version of the Serverless Framework to use (default: latest)'
+    required: false
+    default: latest
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.serverless-version }}
+    - ${{ inputs.args }}

--- a/action.yml
+++ b/action.yml
@@ -7,13 +7,14 @@ branding:
 inputs:
   args:
     description: 'Arguments passed to `serverless`'
-    required: true
+    required: false
+    default: none
   aws-credentials:
     description: 'Whether to use credentials stored in the local environment (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY)'
     required: false
     default: 'false'
   install-packages:
-    description: 'Comma-separated list of packages to install prior to running `serverless {args}`'
+    description: 'Space-separated list of packages to install prior to running `serverless {args}`'
     required: false
     default: none
   serverless-version:

--- a/action.yml
+++ b/action.yml
@@ -29,10 +29,10 @@ runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
+    - ${{ inputs.aws-credentials }}
     - ${{ inputs.working-directory }}
     - ${{ inputs.serverless-version }}
     - ${{ inputs.install-packages }}
-    - ${{ inputs.aws-credentials }}
     - ${{ inputs.args }}
 
 outputs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,14 +1,19 @@
 #!/bin/sh -l
+if [ "$5" = "none" ]; then
+    echo "You need to specify at least one argument, like deploy"
+    exit 1
+fi
+
 cd $1
+
 npm i -g serverless@$2
 
-PACKAGES_TO_INSTALL=$3
-if [ $3 != "none" ]; then
-    npm i -g ${PACKAGES_TO_INSTALL//,/\ }
+if [ "$3" != "none" ]; then
+    npm i -g $3
 fi
 
 WITH_LOCAL_CREDENTIALS=""
-if [ $4 = "true" ] || [ $4 = "yes" ]; then
+if [ "$4" = "true" ] || [ "$4" = "yes" ]; then
     WITH_LOCAL_CREDENTIALS="--use-local-credentials"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,4 @@
 #!/bin/sh -l
-npm i -g serverless@${1/v/}
-serverless $2
+cd $1
+npm i -g serverless@${2/v/}
+serverless $3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,36 @@
 #!/bin/sh -l
 if [ "$5" = "none" ]; then
     echo "You need to specify at least one argument, like deploy"
-    exit 1
-fi
-
-cd $1
-
-npm i -g serverless@$2
-
-if [ "$3" != "none" ]; then
-    npm i -g $3
+    exit 5
 fi
 
 WITH_LOCAL_CREDENTIALS=""
-if [ "$4" = "true" ] || [ "$4" = "yes" ]; then
+if [ "$1" = "true" ] || [ "$1" = "yes" ]; then
+    if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY"]; then
+        echo "You have aws-credentials set without AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY"
+        exit 1
+    fi
     WITH_LOCAL_CREDENTIALS="--use-local-credentials"
+fi
+
+cd $2
+if [ "$?" != 0 ]; then
+    echo "Unable to cd into $2"
+    exit 2
+fi
+
+npm i -g serverless@$3
+if [ "$?" != 0 ]; then
+    echo "Unable to install serverless@$3"
+    exit 3
+fi
+
+if [ "$4" != "none" ]; then
+    npm i -g $4
+    if [ "$?" != 0 ]; then
+        echo "Unable to install packages: $4"
+        exit 4
+    fi
 fi
 
 serverless $5 $WITH_LOCAL_CREDENTIALS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,15 @@
 #!/bin/sh -l
 cd $1
-npm i -g serverless@${2/v/}
-serverless $3
+npm i -g serverless@$2
+
+PACKAGES_TO_INSTALL=$3
+if [ $3 != "none" ]; then
+    npm i -g ${PACKAGES_TO_INSTALL//,/\ }
+fi
+
+WITH_LOCAL_CREDENTIALS=""
+if [ $4 = "true" ] || [ $4 = "yes" ]; then
+    WITH_LOCAL_CREDENTIALS="--use-local-credentials"
+fi
+
+serverless $5 $WITH_LOCAL_CREDENTIALS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -l
+npm i -g serverless@${1/v/}
+serverless $2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ fi
 
 WITH_LOCAL_CREDENTIALS=""
 if [ "$1" = "true" ] || [ "$1" = "yes" ]; then
-    if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY"]; then
+    if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
         echo "You have aws-credentials set without AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY"
         exit 1
     fi
@@ -33,4 +33,5 @@ if [ "$4" != "none" ]; then
     fi
 fi
 
+echo serverless $5 $WITH_LOCAL_CREDENTIALS
 serverless $5 $WITH_LOCAL_CREDENTIALS


### PR DESCRIPTION
Resolves #21
Resolves #33 
Resolves #69 
Resolves #77 
Resolves #84 

Allows a user to specify a `serverless-version` or defaults to `latest`.

Allows a user to specify a `working-directory` or defaults to `.`.

Throws an error if no `args` are passed (with an error message).

Includes an `aws-credentials` flag under `with:` to automatically add `--use-local-credentials` to the end of `args`.

Allows a user to pass a list of plugins in `install-packagages` to be installed before running `args`.

Updates `action.yml` and `README.md`.

_Note:_ Because it calls `/entrypoint.sh` instead of `serverless` directly, specifying the `/bin/sh` entrypoint will include arguments passed to `/entrypoint.sh`. Hence I recommend bumping to v4 as this could be considered a breaking change.

Testing: https://github.com/ryanlawson/actions-test/actions/runs/9142765035/job/25138829111